### PR TITLE
add ability to insert into stubs

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -954,7 +954,8 @@ test "insert into poa stub" {
     defer crs.deinit();
     var root_ = Node{ .poa_stub = .{ .stem = &[_]u8{0xff} ** 31, .commitment = null } };
     var root: *Node = &root_;
+    defer root.tear_down(testing.allocator);
     var value = [_]u8{0} ** 32;
     try root.insert([_]u8{0xff} ** 3 ++ [_]u8{0} ** 29, &value, testing.allocator, &crs);
-    try testing.expectError(error.CanNotOverrideStub, root.insert([_]u8{0xff} ** 32, &value, testing.allocator, &crs));
+    try testing.expectError(error.CanNotOverwriteStub, root.insert([_]u8{0xff} ** 32, &value, testing.allocator, &crs));
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -952,9 +952,9 @@ test "compare simple tree root with that of rust implementation" {
 test "insert into poa stub" {
     var crs = try CRS.init(testing.allocator);
     defer crs.deinit();
-    var root_ = Node{ .poa_stub = .{ .stem = &[_]u8{0xff} ** 31 }, .commitment = null };
+    var root_ = Node{ .poa_stub = .{ .stem = &[_]u8{0xff} ** 31, .commitment = null } };
     var root: *Node = &root_;
     var value = [_]u8{0} ** 32;
-    root.insert([_]u8{0xff} ** 3 ++ [_]u8{0} ** 29, value, testing.allocator, &crs);
+    try root.insert([_]u8{0xff} ** 3 ++ [_]u8{0} ** 29, &value, testing.allocator, &crs);
     try testing.expectError(error.CanNotOverrideStub, root.insert([_]u8{0xff} ** 32, &value, testing.allocator, &crs));
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -952,7 +952,7 @@ test "compare simple tree root with that of rust implementation" {
 test "insert into poa stub" {
     var crs = try CRS.init(testing.allocator);
     defer crs.deinit();
-    var root_ = Node{ .poa_stub = .{ .stem = [_]u8{0xff} ** 31 } };
+    var root_ = Node{ .poa_stub = .{ .stem = &[_]u8{0xff} ** 31 } };
     var root: *Node = &root_;
     var value = [_]u8{0} ** 32;
     root.insert([_]u8{0xff} ** 3 ++ [_]u8{0} ** 29, value, testing.allocator, &crs);

--- a/src/main.zig
+++ b/src/main.zig
@@ -952,7 +952,7 @@ test "compare simple tree root with that of rust implementation" {
 test "insert into poa stub" {
     var crs = try CRS.init(testing.allocator);
     defer crs.deinit();
-    var root_ = Node{ .poa_stub = .{ .stem = &[_]u8{0xff} ** 31 } };
+    var root_ = Node{ .poa_stub = .{ .stem = &[_]u8{0xff} ** 31 }, .commitment = null };
     var root: *Node = &root_;
     var value = [_]u8{0} ** 32;
     root.insert([_]u8{0xff} ** 3 ++ [_]u8{0} ** 29, value, testing.allocator, &crs);


### PR DESCRIPTION
If a leaf is inserted into a stem that is just here to prove a proof of absence, this should lead to several branch nodes being inserted and the poa stem moved down the chain of branch nodes.